### PR TITLE
Fix build workflow path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Copy plugin source into JUCE structure
       run: |
-        cp -R Source JUCE-5.4.7/examples/Plugin%20Host/Source/Plugin  # ruta ejemplo, ajusta si hace falta
+        cp -R Source "JUCE-5.4.7/examples/Plugin Host/Source/Plugin"  # ruta ejemplo, ajusta si hace falta
 
     - name: Generate Xcode project with Projucer
       run: |


### PR DESCRIPTION
## Summary
- fix plugin path for spaces in build workflow

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_683f40ad765083339825ee92e6cf9baf